### PR TITLE
Copy generated declarations to build folder

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pegasys-orchestrate",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "jest --config jestconfig.json",
     "test:watch": "npm run test -- --watch",
     "test:coverage": "npm run test -- --coverage",
-    "build": "npm run clean && tsc",
+    "build": "npm run clean && tsc && cp src/stubs/index.d.ts lib/stubs/index.d.ts",
     "clean": "rimraf ./lib ./coverage",
     "lint": "tslint -p . -c tslint.json",
     "lint:fix": "npm run lint -- --fix",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pegasys-orchestrate",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "The PegaSys Orchestrate library provides convenient access to the PegaSys Orchestrate API from applications written in server-side JavaScript",
   "main": "lib/index.js",
   "files": [


### PR DESCRIPTION
ProtobufJS generates a JS file when generating stubs from proto files. This JS files is simply reused in the build folder by allowing JS files in the project (`"allowJS": true` in tsconfig.json).

ProtobufJS also generates declaration files but these files are not copied in the build folder because declaration files are generated automatically by the compiler from the `.ts` files. Here, given that the logic is in JS and not TS, the compiler creates an empty declaration file of type `any`. 

Given that protobufJS creates that declaration file, we can simply use it by copying it in the build folder.