### PR TITLE
Add try catch to produce function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pegasys-orchestrate",
-  "version": "2.1.0-rc3",
+  "version": "2.1.0-rc4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pegasys-orchestrate",
-  "version": "2.1.0-rc3",
+  "version": "2.1.0-rc4",
   "description": "The PegaSys Orchestrate library provides convenient access to the PegaSys Orchestrate API from applications written in server-side JavaScript",
   "main": "lib/index.js",
   "files": [

--- a/src/kafka/producer/Producer.ts
+++ b/src/kafka/producer/Producer.ts
@@ -59,8 +59,12 @@ export class Producer extends KafkaClient {
   public async produce(topic: string, message: KakfaJS.Message): Promise<KakfaJS.RecordMetadata> {
     this.checkReadiness()
 
-    const result = await this.producer.send({ topic, messages: [message] })
-    return result[0]
+    try {
+      const result = await this.producer.send({ topic, messages: [message] })
+      return result[0]
+    } catch (error) {
+      throw error
+    }
   }
 
   /**


### PR DESCRIPTION
When using KafkaJS, we do not try catch the call to the send function so we are not aware of errors thrown by the Kafka client.