### PR TITLE
Types alignment

### DIFF
--- a/examples/register-chain/app.ts
+++ b/examples/register-chain/app.ts
@@ -7,8 +7,8 @@ export const start = async () => {
     const chainRegistry = new ChainRegistry('http://localhost:8011')
 
     await chainRegistry.registerChain({
-      name: 'MyChain',
-      urls: ['http://geth:8545'],
+      name: 'besu',
+      urls: ['http://validator2:8545'],
       listener: {
         externalTxEnabled: true,
         backoffDuration: '5s',

--- a/examples/send-onetimekey-tx/app.ts
+++ b/examples/send-onetimekey-tx/app.ts
@@ -15,7 +15,9 @@ export const start = async () => {
           to: '0x4a435585d27cd7e6dae2c714be8e414b5fd7d257',
           methodSignature: 'transfer(address,uint256)',
           args: ['0x6009608a02a7a15fd6689d6dad560c44e9ab61ff', 5000],
-          oneTimeKey: true
+          annotations: {
+            oneTimeKey: true
+          }
         }
       },
       'ExampleOneTimeKey'

--- a/examples/send-raw-tx/app.ts
+++ b/examples/send-raw-tx/app.ts
@@ -16,7 +16,7 @@ export const start = async () => {
     console.log('Generated address:', wallet.address)
 
     // We send 1 ETH to some other account
-    const signedTransaction = await wallet.sign({
+    const signedTransaction = await wallet.signTransaction({
       nonce: 0,
       gasLimit: 21000,
       to: '0xdbb881a51cd4023e4400cef3ef73046743f08da3',

--- a/examples/send-tx/app.ts
+++ b/examples/send-tx/app.ts
@@ -13,7 +13,7 @@ export const start = async () => {
         chain: 'besu',
         params: {
           from: '0x7e654d251da770a068413677967f6d3ea2fea9e4', // Default Orchestrate account in development mode
-          to: '0xe5ce65038f9d1c841a33CC816eE674F8a0E31E74',
+          to: '{DEPLOYED_CONTRACT_ADDRESS}',
           methodSignature: 'transfer(address,uint256)',
           args: ['0x6009608a02a7a15fd6689d6dad560c44e9ab61ff', 5000]
         }

--- a/examples/send-tx/app.ts
+++ b/examples/send-tx/app.ts
@@ -13,7 +13,7 @@ export const start = async () => {
         chain: 'besu',
         params: {
           from: '0x7e654d251da770a068413677967f6d3ea2fea9e4', // Default Orchestrate account in development mode
-          to: '{DEPLOYED_CONTRACT_ADDRESS}',
+          to: '0xe5ce65038f9d1c841a33CC816eE674F8a0E31E74',
           methodSignature: 'transfer(address,uint256)',
           args: ['0x6009608a02a7a15fd6689d6dad560c44e9ab61ff', 5000]
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pegasys-orchestrate",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pegasys-orchestrate",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "The PegaSys Orchestrate library provides convenient access to the PegaSys Orchestrate API from applications written in server-side JavaScript",
   "main": "lib/index.js",
   "files": [

--- a/src/http/transactions/Transactions.test.ts
+++ b/src/http/transactions/Transactions.test.ts
@@ -18,7 +18,7 @@ import { TransactionClient } from './Transactions'
 const mockJobLogRes: ILog = {
   message: 'Job Created',
   status: 'CREATED',
-  createdAt: new Date()
+  at: new Date()
 }
 
 const mockJobRes: IJobResponse = {
@@ -28,7 +28,8 @@ const mockJobRes: IJobResponse = {
   transaction: {},
   status: 'STARTED',
   type: 'eth://ethereum/transaction',
-  createdAt: new Date()
+  createdAt: new Date(),
+  updatedAt: new Date()
 }
 
 const mockScheduleRes: IScheduleResponse = {
@@ -42,6 +43,7 @@ const mockETHParams: IETHTransactionParams = {}
 const mockTransactionResp: ITransactionResponse = {
   uuid: 'transactionUUID',
   idempotencyKey: 'idempotencyKey',
+  chain: 'MyChain',
   params: mockETHParams,
   schedule: mockScheduleRes,
   createdAt: new Date()

--- a/src/http/types/IAnnotations.ts
+++ b/src/http/types/IAnnotations.ts
@@ -1,4 +1,6 @@
-export interface IAnnotationsResponse {
+import { Priority } from './Priority'
+
+export interface IAnnotations {
   oneTimeKey?: boolean
-  chainID?: string
+  priority?: Priority
 }

--- a/src/http/types/IJob.ts
+++ b/src/http/types/IJob.ts
@@ -1,4 +1,4 @@
-import { IAnnotationsResponse } from './IAnnotations'
+import { IAnnotations } from './IAnnotations'
 import { IETHTransaction } from './IETHTransaction'
 import { ILog } from './ILog'
 
@@ -8,8 +8,9 @@ export interface IJobResponse {
   transaction: IETHTransaction
   logs: ILog[]
   labels?: object
-  annotations?: IAnnotationsResponse
+  annotations?: IAnnotations
   status: string
   type: string
   createdAt: Date
+  updatedAt: Date
 }

--- a/src/http/types/ILog.ts
+++ b/src/http/types/ILog.ts
@@ -1,5 +1,5 @@
 export interface ILog {
   status: string
   message: string
-  createdAt: Date
+  at: Date
 }

--- a/src/http/types/ITransaction.ts
+++ b/src/http/types/ITransaction.ts
@@ -1,15 +1,31 @@
 import { ParsedQs } from 'qs'
 
+import { IAnnotations } from './IAnnotations'
 import { IScheduleResponse } from './ISchedule'
 import { Priority } from './Priority'
 import { ProtocolType } from './ProtocolType'
 
+interface IBaseRequest {
+  chain: string
+  labels?: object
+}
+
 export interface ISendTransactionRequest extends IBaseRequest {
   params: ITransactionParams
+}
+interface ITransactionParams extends IBaseTransactionParams, IPrivateTransactionParams {
+  to: string
+  methodSignature: string
+  annotations?: IAnnotations
 }
 
 export interface IDeployContractRequest extends IBaseRequest {
   params: IDeployContractParams
+}
+interface IDeployContractParams extends IBaseTransactionParams, IPrivateTransactionParams {
+  contractName: string
+  contractTag?: string
+  annotations?: IAnnotations
 }
 
 export interface ISendRawRequest extends IBaseRequest {
@@ -36,37 +52,18 @@ export interface ISearchRequest extends ParsedQs {
 export interface ITransactionResponse {
   uuid: string
   idempotencyKey: string
+  chain: string
   params: IETHTransactionParams
   schedule: IScheduleResponse
   createdAt: Date
 }
 
-interface IBaseRequest {
-  chain: string
-  labels?: object
-}
-
-interface ITransactionParams extends IBaseTransactionParams, IPrivateTransactionParams {
-  methodSignature: string
-  oneTimeKey?: boolean
-  priority?: Priority
-}
-
-interface IDeployContractParams extends IBaseTransactionParams, IPrivateTransactionParams {
-  contractName: string
-  contractTag?: string
-  oneTimeKey?: boolean
-  priority?: Priority
-}
-
 export interface IETHTransactionParams extends IBaseTransactionParams, IPrivateTransactionParams {
   raw?: string
-  nonce?: string
 }
 
 interface IBaseTransactionParams {
   from?: string
-  to?: string
   value?: string
   gas?: string
   gasPrice?: string


### PR DESCRIPTION
- Align SDK types with Orchestrate types for Orchestrate v2.3 before release
- Use Besu as name when registering new chain
- Fix bug in examples: Use `signTransaction` instead of `sign` that does not exist anymore in ethers 5.x